### PR TITLE
fix for syncing tile load events when cache primed

### DIFF
--- a/lib/time/controls.js
+++ b/lib/time/controls.js
@@ -116,24 +116,21 @@ function TimeController(model, slider, timeline, controls) {
     function schedule() {
         if (started) {
             // @todo respect playback interval options...
-            if (deferred.length > 0) {
-                $.when.apply($, deferred).then(function() {
-                    if (started) {
-                        timeout = window.setTimeout(move, 1000, 1);
-                    }
-                }, function() {
-                    // the deferred was rejected, if arguments provided, this
-                    // represents an error state so don't continue playing
-                    if (arguments.length === 0 && started && timeout === null) {
-                        timeout = window.setTimeout(move, 1000, 1);
-                    } else {
-                        self.stop();
-                    }
-                });
-                deferred = [];
-            } else {
-                timeout = window.setTimeout(move, 1000, 1);
-            }
+            var wait = 1000;
+            $.when.apply($, deferred).then(function() {
+                if (started) {
+                    timeout = window.setTimeout(move, wait, 1);
+                }
+            }, function() {
+                // the deferred was rejected, if arguments provided, this
+                // represents an error state so don't continue playing
+                if (arguments.length === 0 && started && timeout === null) {
+                    timeout = window.setTimeout(move, wait, 1);
+                } else {
+                    self.stop();
+                }
+            });
+            deferred = [];
         }
     }
 

--- a/lib/time/maps.js
+++ b/lib/time/maps.js
@@ -107,7 +107,7 @@ function TileLoadListener(tileStatusCallback) {
         }
         return t;
     }
-    return {
+    var listener = {
         deferred: deferred,
         cancel: function() {
             cancelled = true;
@@ -141,6 +141,16 @@ function TileLoadListener(tileStatusCallback) {
             }
         }
     };
+    // workaround for when the tiles are cached and no events are triggered
+    // this adds a constant (small) additional delay to the current play rate
+    // under optimal (cached) conditions
+    // @todo can this safely be shortened?
+    window.setTimeout(function() {
+        if (Object.keys(tilesLoading).length === 0) {
+            listener.cancel();
+        }
+    },100);
+    return listener;
 }
 
 exports.MapController = function(options, timeControls) {


### PR DESCRIPTION
@bartvde I played with this a bit and it seemed to work as intended. Mind checking, too?
