### PR TITLE
initial svg icon support

### DIFF
--- a/dev-server.js
+++ b/dev-server.js
@@ -8,14 +8,19 @@ exports.run = function() {
         port: 8001,
         livereload: true,
         middleware: function(connect, o) {
-            var fixedProxy = (function() {
+            var gsProxy = (function() {
                 var options = url.parse('http://mapstory.org/geoserver');
                 options.route = '/geoserver';
                 return proxy(options);
             })();
-            var fixedProxyMaps = (function() {
+            var mapsProxy = (function() {
                 var options = url.parse('http://mapstory.org/maps');
                 options.route = '/maps';
+                return proxy(options);
+            })();
+            var assetsProxy = (function() {
+                var options = url.parse('http://mapstory.dev.opengeo.org/mapstory-assets');
+                options.route = '/assets';
                 return proxy(options);
             })();
             var dynamicProxy = function(req, res, next) {
@@ -28,7 +33,7 @@ exports.run = function() {
                 }
                 return next();
             };
-            return [fixedProxy, fixedProxyMaps, dynamicProxy];
+            return [gsProxy, mapsProxy, assetsProxy, dynamicProxy];
         }
     });
 };

--- a/examples/style-example.html
+++ b/examples/style-example.html
@@ -13,7 +13,7 @@
         <script type="text/javascript" src="../bower_components/bootstrap/dist/js/bootstrap.min.js"></script>
         <script type="text/javascript" src="../bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
         <script type="text/javascript" src="../bower_components/angular-bootstrap-colorpicker/js/bootstrap-colorpicker-module.js"></script>
-        <script src="ol-debug.js" type="text/javascript"></script>
+        <script src="ol.js" type="text/javascript"></script>
         <script type="text/javascript" src="../dist/mapstory-style-editor-tpls.js"></script>
         <script type="text/javascript" src="../dist/mapstory-style-editor.js"></script>
         <script type="text/javascript" src="style-example.js"></script>

--- a/examples/style-example.js
+++ b/examples/style-example.js
@@ -47,7 +47,7 @@
         ], ['l1','l2','l3']);
     }
 
-    module.run(function() {
+    module.run(function(iconCommons) {
         map = new ol.Map({
             layers: [new ol.layer.Tile({
                     source: new ol.source.MapQuest({layer: 'sat'})
@@ -186,6 +186,25 @@
                 defer.resolve(results);
                 return defer.promise;
             }
+        };
+    });
+
+    module.factory('iconCommonsImpl', function() {
+        return {
+            defaults: ["golf-18.svg",
+                "cafe-18.svg",
+                "restaurant-18.svg",
+                "car-18.svg",
+                "harbor-18.svg",
+                "hospital-18.svg",
+                "farm-18.svg",
+                "zoo-18.svg",
+                "water-18.svg",
+                "heart-18.svg",
+                "town-hall-18.svg",
+                "industrial-18.svg"].map(function(n) {
+                return '/assets/style_editor/icons/' + n;
+            })
         };
     });
 

--- a/lib/style/directives/directives.js
+++ b/lib/style/directives/directives.js
@@ -74,7 +74,7 @@
         };
     });
 
-    module.directive('graphicEditor', function(stStyleChoices, ol3MarkRenderer) {
+    module.directive('graphicEditor', function(stStyleChoices, ol3MarkRenderer, iconCommons, stSvgIcon) {
         return {
             restrict: 'E',
             templateUrl: 'widgets/graphic-editor.html',
@@ -85,9 +85,16 @@
             link: function(scope, element, attrs) {
                 scope.styleChoices = stStyleChoices;
                 function canvas(symbol) {
-                    var img = angular.element(ol3MarkRenderer(symbol, 24));
-                    img.addClass('symbol-icon');
-                    return img;
+                    var el = angular.element(ol3MarkRenderer(symbol, 24));
+                    el.addClass('symbol-icon');
+                    return el;
+                }
+                function image(icon) {
+                    var el = angular.element('<img>');
+                    el.attr('src', icon.dataURI);
+                    el.addClass('symbol-icon');
+                    el.attr('graphic', icon.uri);
+                    return el;
                 }
                 // update the element with the data-current-symbol attribute
                 // to match the current symbol
@@ -101,12 +108,22 @@
                         }
                     }
                     el.find('*').remove();
-                    el.append(canvas(scope.symbol.shape));
+                    if (scope.symbol.shape) {
+                        el.append(canvas(scope.symbol.shape));
+                    } else {
+                        stSvgIcon.getImage(scope.symbol.graphic, '#000', '#fff').then(function(icon) {
+                            el.append(image(icon));
+                        });
+                    }
                 }
                 var clicked = function() {
                     var el = angular.element(this);
                     if (el.attr('shape')) {
                         scope.symbol.shape = el.attr('shape');
+                        scope.symbol.graphic = null;
+                    } else if (el.attr('graphic')) {
+                        scope.symbol.shape = null;
+                        scope.symbol.graphic = el.attr('graphic');
                     }
                     current();
                 };
@@ -118,6 +135,14 @@
                     img.attr('shape', s);
                     img.on('click', clicked);
                     list.append(img);
+                });
+                iconCommons.defaults().then(function(icons) {
+                    icons.forEach(function(icon, i) {
+                        var img = image(icon);
+                        img.attr('id', 'svg' + i);
+                        img.on('click', clicked);
+                        list.append(img);
+                    });
                 });
                 current();
             }

--- a/lib/style/services/ol3StyleConverter.js
+++ b/lib/style/services/ol3StyleConverter.js
@@ -17,7 +17,7 @@
         };
     });
 
-    module.factory('ol3StyleConverter', function() {
+    module.factory('ol3StyleConverter', function(stSvgIcon) {
         return {
             generateShapeConfig: function(style, fill, stroke) {
                 var shape = style.symbol.shape,
@@ -76,7 +76,14 @@
             },
             generateShape: function(style, fill, stroke) {
                 var config = this.generateShapeConfig(style, fill, stroke);
-                if (style.symbol.shape === 'circle') {
+                if (style.symbol.graphic) {
+                    var info = stSvgIcon.getImage(style.symbol.graphic, fill.getColor(), stroke.getColor(), true);
+                    return new ol.style.Icon({
+                        src: info.dataURI,
+                        scale: style.symbol.size / Math.max(info.width, info.height),
+                        opacity: style.symbol.opacity
+                    });
+                } else if (style.symbol.shape === 'circle') {
                     return new ol.style.Circle(config);
                 } else {
                     return new ol.style.RegularShape(config);

--- a/lib/style/services/services.js
+++ b/lib/style/services/services.js
@@ -5,7 +5,8 @@
         'mapstory.styleEditor.ol3StyleConverter',
         'mapstory.styleEditor.styleRuleBuilder',
         'mapstory.styleEditor.styleChoices',
-        'mapstory.styleEditor.styleTypes'
+        'mapstory.styleEditor.styleTypes',
+        'mapstory.styleEditor.svgIcon',
     ]);
 
 })();

--- a/lib/style/services/svgIcon.js
+++ b/lib/style/services/svgIcon.js
@@ -1,0 +1,95 @@
+(function() {
+    'use strict';
+
+    var module = angular.module('mapstory.styleEditor.svgIcon', []);
+
+    module.factory('stSvgIcon', function($cacheFactory, $http, $q, $log) {
+        var element = angular.element(document.createElement('div'));
+        var imageCache = $cacheFactory('stSvgImage');
+        var dataCache = $cacheFactory('stSvgData');
+        function process(svg, fill, stroke) {
+            element.html(svg);
+            // @todo make smarter
+            ['path', 'rect'].forEach(function(el) {
+                angular.forEach(element.find(el), function(e) {
+                    // @todo does it make sense to override stroke width?
+                    e = angular.element(e);
+                    var css = {
+                        opacity: 1
+                    };
+                    var existingFill = e.css('fill');
+                    if (existingFill != 'none' && existingFill != 'rgb(255, 255, 255)') {
+                        css.fill = fill;
+                    }
+                    var existingStroke = e.css('stroke');
+                    if (existingStroke != 'none') {
+                        css.stroke = stroke;
+                    }
+                    e.css(css);
+                });
+            });
+            var root = element.find('svg');
+            return {
+                dataURI: 'data:image/svg+xml;base64,' + btoa(element.html()),
+                width: parseInt(root.attr('width')),
+                height: root.attr('height')
+            };
+        }
+        return {
+            getImage: function(svgURI, fill, stroke, sync) {
+                var key = svgURI + fill + stroke;
+                var cached = imageCache.get(key);
+                var deferred = $q.defer();
+                if (cached) {
+                    if (sync) {
+                        return cached;
+                    }
+                    deferred.resolve(cached);
+                } else {
+                    if (sync) {
+                        var svg = dataCache.get(svgURI);
+                        if (svg) {
+                            var imageInfo = process(svg, fill, stroke);
+                            imageInfo.uri = svgURI;
+                            imageCache.put(key, imageInfo);
+                            return imageInfo;
+                        }
+                        return null;
+                    }
+                    this.getImageData(svgURI).success(function(data) {
+                         var imageInfo = process(data, fill, stroke);
+                         imageInfo.uri = svgURI;
+                         imageCache.put(key, imageInfo);
+                         deferred.resolve(imageInfo);
+                         dataCache.put(svgURI, data);
+                    }).error(function() {
+                         $log.warn('error fetching ' + svgURI);
+                         deferred.reject('error');
+                    });
+                }
+                return deferred.promise;
+            },
+            getImageData: function(svgURI) {
+                return $http.get(svgURI, {cache: true});
+            }
+        };
+    });
+
+    module.factory('iconCommons', function($injector, $q, stSvgIcon) {
+        var impl;
+        if ($injector.has('iconCommonsImpl')) {
+            impl = $injector.get('iconCommonsImpl');
+        } else {
+            impl = {
+                defaults: []
+            };
+        }
+        return {
+            defaults: function() {
+                return $q.all(impl.defaults.map(function(uri) {
+                    return stSvgIcon.getImage(uri, '#000', '#fff');
+                }));
+            }
+        };
+    });
+})();

--- a/lib/style/style.less
+++ b/lib/style/style.less
@@ -28,7 +28,7 @@
 }
 
 .style-editor-item .symbol-icon {
-    height: 1em;
+    height: 1.5em;
     vertical-align: middle;
 }
 

--- a/test/test-ol3StyleConverter.js
+++ b/test/test-ol3StyleConverter.js
@@ -1,10 +1,12 @@
 require('../lib/style/services/ol3StyleConverter.js');
+require('../lib/style/services/svgIcon.js');
 
 describe('ol3StyleConverter', function() {
 
     beforeEach(function() {
         // window.angular.mock.module is work around browserify conflict
         window.angular.mock.module('mapstory.styleEditor.ol3StyleConverter');
+        window.angular.mock.module('mapstory.styleEditor.svgIcon');
 
         inject(function(ol3StyleConverter) {
             this.ol3StyleConverter = ol3StyleConverter;


### PR DESCRIPTION
@bartvde 

Main thing to note is that icon fetching is async but in the ol3 style building we're using a synchronous API because it seems like there is no way to modify the style once built - like trigger the fetch, then update the style on completion.

Another approach would be to ensure that any async loads trigger the style refresh.

The current approach works fine but requires the remote resources are resolve prior. This currently is safe as the 'default' icons are all resolved on page load but we'll have to eventually deal with the case when they are not.

I also put ol3 non-debug build back in the style example to avoid using 'hidden' API :santa: 
