### PR TITLE
need to get and use attribute data type

### DIFF
--- a/examples/common.js
+++ b/examples/common.js
@@ -198,6 +198,11 @@
             }).success(function(data) {
                 var wfs = new storytools.edit.WFSDescribeFeatureType.WFSDescribeFeatureType();
                 var layerInfo = wfs.parseResult(data);
+                if (layerInfo.timeAttr !== null) {
+                    layer.set('timeAttribute', layerInfo.timeAttr);
+                } else {
+                    return getTimeAttribute(layer);
+                }
                 var parts = id.split(':');
                 layerInfo.typeName = id;
                 layerInfo.featurePrefix = parts[0];
@@ -277,7 +282,10 @@
         }
         function getTimeAttribute(layer) {
             var promise;
-            if (layer.get('server').timeEndpoint) {
+            if (layer.get('timeAttribute')) {
+                promise = $q.when('');
+            }
+            else if (layer.get('server').timeEndpoint) {
                 var url = layer.get('server').timeEndpoint(layer);
                 $http.get(url).success(function(data) {
                     layer.set('timeAttribute', data.attribute);
@@ -290,7 +298,7 @@
             return promise;
         }
         function load(layer, styleName) {
-            return $q.all(loadCapabilities(layer, styleName), describeFeatureType(layer), getStyleName(layer, styleName), getTimeAttribute(layer));
+            return $q.all(loadCapabilities(layer, styleName), describeFeatureType(layer), getStyleName(layer, styleName));
         }
     }
 

--- a/lib/core/time/maps.js
+++ b/lib/core/time/maps.js
@@ -199,7 +199,7 @@ exports.MapController = function(options, timeControls) {
         tileStatusCallback = options.tileStatusCallback,
         map = options.map;
     function layerAdded(layer) {
-        var source;
+        var source, image;
         if (layer instanceof ol.layer.Tile && layer.getSource() instanceof ol.source.TileWMS) {
             source = layer.getSource();
             source.setTileLoadFunction((function() {
@@ -210,7 +210,7 @@ exports.MapController = function(options, timeControls) {
                     var currentListener = loadListener;
                     if (currentListener) {
                         currentListener.tileQueued(source);
-                        var image = tile.getImage();
+                        image = tile.getImage();
                         // @todo handle onerror and cancel deferred with an example
                         // to stop automatic playback
                         image.onload = image.onerror = function(event) {
@@ -227,12 +227,12 @@ exports.MapController = function(options, timeControls) {
                     // grab the active loadListener to avoid phantom onloads
                     // when listener is cancelled
                     var currentListener = loadListener;
-                    var image = image.getImage();
+                    image = image.getImage();
                     if (currentListener) {
                         currentListener.tileQueued(source);
                         image.onload = image.onerror = function(event) {
                             currentListener.tileLoaded(event, source);
-                        }
+                        };
                     }
                     image.src = src;
                 };

--- a/lib/edit/style/WFSDescribeFeatureType.js
+++ b/lib/edit/style/WFSDescribeFeatureType.js
@@ -35,7 +35,7 @@ exports.WFSDescribeFeatureType = function() {
                     timeAttr = null;
                 }
             }
-            fields.push({name: el.name, type: el.type.localPart});
+            fields.push({name: el.name, type: el.type.localPart, typeNS: el.type.namespaceURI});
         }
         return {
             timeAttr: timeAttr,

--- a/lib/edit/style/WFSDescribeFeatureType.js
+++ b/lib/edit/style/WFSDescribeFeatureType.js
@@ -16,10 +16,11 @@ exports.WFSDescribeFeatureType = function() {
         var featureNS = schema.targetNamespace;
         var element = schema.complexType[0].complexContent.extension.sequence.element;
         var fields = [];
-        var geometryType;
+        var geometryType, timeAttr;
         for (var i=0, ii=element.length; i<ii; ++i) {
-            if (element[i].type.namespaceURI === 'http://www.opengis.net/gml') {
-                var lp = element[i].type.localPart;
+            var el = element[i];
+            if (el.type.namespaceURI === 'http://www.opengis.net/gml') {
+                var lp = el.type.localPart;
                 if (lp.indexOf('Polygon') !== -1) {
                     geometryType = 'polygon';
                 } else if (lp.indexOf('LineString') !== -1) {
@@ -27,12 +28,17 @@ exports.WFSDescribeFeatureType = function() {
                 } else if (lp.indexOf('Point') !== -1) {
                     geometryType = 'point';
                 }
+            } else if (el.type.localPart === 'dateTime') {
+                if (timeAttr === undefined) {
+                    timeAttr = el.name;
+                } else {
+                    timeAttr = null;
+                }
             }
-            // TODO also register type (namespaceURI and localPart)
-            fields.push(element[i].name);
-            // TODO: try to detect a time attribute (indeterminate if more than one...)
+            fields.push({name: el.name, type: el.type.localPart});
         }
         return {
+            timeAttr: timeAttr,
             featureNS: featureNS,
             geomType: geometryType,
             attributes: fields

--- a/lib/ng/edit/style/directives/directives.js
+++ b/lib/ng/edit/style/directives/directives.js
@@ -50,7 +50,8 @@
             scope: {
                 stModel: "=stModel",
                 filter: "@filter",
-                css: "@css"
+                css: "@css",
+                stType: "@stType"
             },
             link: function(scope, element, attrs) {
                 scope.$watch(function() {
@@ -71,6 +72,16 @@
                     scope.attributes.sort();
                 });
                 scope.model = scope.stModel;
+                if (scope.stType === "label") {
+                    scope.onSelect = function(attribute) {
+                        scope.model.attribute=attribute;
+                    };
+                } else if (scope.stType === "classify") {
+                    scope.onSelect = function(attribute) {
+                        // TODO unsure how to get this part to work
+                        //changeClassifyProperty('attribute',attribute);
+                    };
+                }
             }
         };
     });

--- a/lib/ng/edit/style/directives/directives.js
+++ b/lib/ng/edit/style/directives/directives.js
@@ -43,6 +43,38 @@
         };
     });
 
+    module.directive('attributeCombo', function() {
+        return {
+            restrict: 'E',
+            templateUrl: 'style/widgets/attribute-combo.html',
+            scope: {
+                stModel: "=stModel",
+                filter: "@filter",
+                css: "@css"
+            },
+            link: function(scope, element, attrs) {
+                scope.$watch(function() {
+                    return scope.$parent.layer;
+                }, function(neu) {
+                    scope.attributes = [];
+                    var attributes = neu.get('layerInfo').attributes;
+                    for (var i=0, ii=attributes.length; i<ii; ++i) {
+                        var attr = attributes[i];
+                        if (scope.filter === 'nogeom') {
+                            if (attr.typeNS !== 'http://www.opengis.net/gml') {
+                                scope.attributes.push(attr.name);
+                            }
+                        } else {
+                            scope.attributes.push(attr.name);
+                        }
+                    }
+                    scope.attributes.sort();
+                });
+                scope.model = scope.stModel;
+            }
+        };
+    });
+
     editorDirective('symbolEditor', 'symbol-editor.html', 'symbol', function(scope, el, attrs) {
         ['showGraphic', 'showRotation'].forEach(function(opt) {
             scope[opt] = attrs[opt];

--- a/lib/templates/edit/style/widgets/attribute-combo.html
+++ b/lib/templates/edit/style/widgets/attribute-combo.html
@@ -4,6 +4,6 @@
     </button>
     <ul class="dropdown-menu scrollable-combo {{css}}" role="menu">
         <li ng-click="model.attribute=null">[ None ]</li>
-        <li ng-repeat="attribute in attributes" ng-click="model.attribute=attribute">{{attribute}}</li>
+        <li ng-repeat="attribute in attributes" ng-click="onSelect(attribute)">{{attribute}}</li>
     </ul>
 </div>

--- a/lib/templates/edit/style/widgets/attribute-combo.html
+++ b/lib/templates/edit/style/widgets/attribute-combo.html
@@ -1,0 +1,9 @@
+<div data-dropdown>
+    <button type="button" class="dropdown-toggle">
+        {{model.attribute||'Select Attribute'}}<span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu scrollable-combo {{css}}" role="menu">
+        <li ng-click="model.attribute=null">[ None ]</li>
+        <li ng-repeat="attribute in attributes" ng-click="model.attribute=attribute">{{attribute}}</li>
+    </ul>
+</div>

--- a/lib/templates/edit/style/widgets/classify-editor.html
+++ b/lib/templates/edit/style/widgets/classify-editor.html
@@ -6,7 +6,7 @@
                 {{activeStyle.classify.attribute || 'Select Attribute'}}<span class="caret"></span>
             </button>
             <ul class="dropdown-menu scrollable-combo classify-attribute" role="menu">
-                <li ng-repeat="attribute in layer.get('layerInfo').attributes" ng-click="changeClassifyProperty('attribute',attribute)">{{attribute}}</li>
+                <li ng-repeat="attribute in layer.get('layerInfo').attributes" ng-click="changeClassifyProperty('attribute',attribute.name)">{{attribute.name}}</li>
             </ul>
         </div>
 

--- a/lib/templates/edit/style/widgets/classify-editor.html
+++ b/lib/templates/edit/style/widgets/classify-editor.html
@@ -1,15 +1,7 @@
 <div class="style-editor-item">
     <div class="title">Classification</div>
     <div class="controls">
-        <div class="btn-group" data-dropdown >
-            <button type="button" class="dropdown-toggle"   >
-                {{activeStyle.classify.attribute || 'Select Attribute'}}<span class="caret"></span>
-            </button>
-            <ul class="dropdown-menu scrollable-combo classify-attribute" role="menu">
-                <li ng-repeat="attribute in layer.get('layerInfo').attributes" ng-click="changeClassifyProperty('attribute',attribute.name)">{{attribute.name}}</li>
-            </ul>
-        </div>
-
+        <attribute-combo st-model="activeStyle.classify" st-type="classify" css="classify-attribute" filter="nogeom"></attribute-combo>
         <div class="btn-group" ng-if="showMaxClasses">
             <input class="btn-xs" size="3" type="number" min="0" step="1" ng-model="activeStyle.classify.maxClasses" ng-change="changeClassifyProperty()"   />
         </div>

--- a/lib/templates/edit/style/widgets/label-editor.html
+++ b/lib/templates/edit/style/widgets/label-editor.html
@@ -1,7 +1,7 @@
 <div ng-form="label" class="style-editor-item">
     <div class="title">Label</div>
     <div class="controls">
-        <attribute-combo st-model="model" css="label-attribute" filter="nogeom"></attribute-combo>
+        <attribute-combo st-model="model" st-type="label" css="label-attribute" filter="nogeom"></attribute-combo>
         <number-editor st-model="model" property="fontSize"></number-editor>
     </div>
     <div class="controls">

--- a/lib/templates/edit/style/widgets/label-editor.html
+++ b/lib/templates/edit/style/widgets/label-editor.html
@@ -1,15 +1,7 @@
 <div ng-form="label" class="style-editor-item">
     <div class="title">Label</div>
     <div class="controls">
-        <div data-dropdown>
-            <button type="button" class="dropdown-toggle"   >
-                {{model.attribute||'Select Attribute'}}<span class="caret"></span>
-            </button>
-            <ul class="dropdown-menu scrollable-combo label-attribute" role="menu">
-                <li ng-click="model.attribute=null">[ None ]</li>
-                <li ng-repeat="attribute in layer.get('layerInfo').attributes" ng-click="model.attribute=attribute.name">{{attribute.name}}</li>
-            </ul>
-        </div>
+        <attribute-combo st-model="model" css="label-attribute" filter="nogeom"></attribute-combo>
         <number-editor st-model="model" property="fontSize"></number-editor>
     </div>
     <div class="controls">

--- a/lib/templates/edit/style/widgets/label-editor.html
+++ b/lib/templates/edit/style/widgets/label-editor.html
@@ -7,7 +7,7 @@
             </button>
             <ul class="dropdown-menu scrollable-combo label-attribute" role="menu">
                 <li ng-click="model.attribute=null">[ None ]</li>
-                <li ng-repeat="attribute in layer.get('layerInfo').attributes" ng-click="model.attribute=attribute">{{attribute}}</li>
+                <li ng-repeat="attribute in layer.get('layerInfo').attributes" ng-click="model.attribute=attribute.name">{{attribute.name}}</li>
             </ul>
         </div>
         <number-editor st-model="model" property="fontSize"></number-editor>


### PR DESCRIPTION
From the DescribeFeatureType response, we should story the type along with the name. For example, `type="xsd:string"`. I'm fine using XML schema types (`xsd:string`) in this case but could be persuaded to just drop the prefix. Either way, something like: `gml:PointPropertyType` kinda sucks.

This could be somewhat of an invasive, breaking change (and it's all my fault :wink:) so lets coordinate.

A fix should include extraction of any inline attribute dropdown markup[1] to a directive. And the tests I didn't write yet.

This would help address #142

[1] for example: https://github.com/MapStory/story-tools/blob/da985740eefb0831a9f03e0ca3717961689881bb/lib/templates/edit/style/widgets/label-editor.html#L4