### PR TITLE
scope currentEditor can be undefined

### DIFF
--- a/lib/ng/edit/style/directives/directives.js
+++ b/lib/ng/edit/style/directives/directives.js
@@ -245,9 +245,13 @@
             link: function(scope, element, attrs) {
                 scope.$watch('currentEditor', function() {
                     var currentEditor = scope.currentEditor;
-                    var templateUrl = 'style/types/' + currentEditor.name.replace(' ', '-') + ".html";
-                    element.html($templateCache.get(templateUrl));
-                    $compile(element.contents())(scope);
+                    if (scope.currentEditor) {
+                        var templateUrl = 'style/types/' + currentEditor.name.replace(' ', '-') + ".html";
+                        element.html($templateCache.get(templateUrl));
+                        $compile(element.contents())(scope);
+                    } else {
+                        element.html('');
+                    }
                 });
             }
         };


### PR DESCRIPTION
@ischneider do you have any ideas why I run into this intermittently when loading saved maps? Is a simple if statement enough, or is there a different root cause that should be handled?

![screen shot 2015-01-27 at 11 28 22](https://cloud.githubusercontent.com/assets/319678/5916955/acb434ee-a617-11e4-9ff0-08eccc953100.png)
