### PR TITLE
only store timeAttribute once

### DIFF
--- a/examples/common.js
+++ b/examples/common.js
@@ -277,9 +277,7 @@
             }).success(function(data) {
                 var wfs = new storytools.edit.WFSDescribeFeatureType.WFSDescribeFeatureType();
                 var layerInfo = wfs.parseResult(data);
-                if (layerInfo.timeAttr !== null) {
-                    layer.set('timeAttribute', layerInfo.timeAttr);
-                } else {
+                if (layerInfo.timeAttribute === null) {
                     getTimeAttribute(layer);
                 }
                 var parts = id.split(':');
@@ -317,7 +315,7 @@
                 );
             layer.setExtent(extent);
             if (name in found) {
-                layer.set('times', found[name]);
+                angular.extend(layer.get('layerInfo') || {}, {times: found[name]});
                 start = found[name].start || found[name][0];
             }
             if (layer instanceof ol.layer.Tile) {
@@ -361,16 +359,16 @@
         }
         function getTimeAttribute(layer) {
             var promise;
-            if (layer.get('timeAttribute')) {
+            if (layer.get('layerInfo').timeAttribute) {
                 promise = $q.when('');
             }
             else if (layer.get('server') && layer.get('server').timeEndpoint) {
                 var url = layer.get('server').timeEndpoint(layer);
                 $http.get(url).success(function(data) {
-                    layer.set('timeAttribute', data.attribute);
+                    angular.extend(layer.get('layerInfo') || {}, {timeAttribute: data.attribute});
                     if (data.endAttribute) {
                         // @todo verify this with sample from mapstory that has endAttribute
-                        layer.set('endTimeAttribute', data.endAttribute);
+                        angular.extend(layer.get('layerInfo') || {}, {endTimeAttribute: data.endAttribute});
                     }
                 });
             } else {

--- a/examples/full-example.html
+++ b/examples/full-example.html
@@ -209,7 +209,7 @@
                             <div ng-repeat="lyr in map.map.getLayers().getArray()">
                                 <h4>ID: {{ lyr.get('id') }}</h4>
                                 <pre>title = {{ lyr.get('title') | json }}</pre>
-                                <pre>times = {{ lyr.get('times') | json }}</pre>
+                                <pre>times = {{ lyr.get('layerInfo').times | json }}</pre>
                                 <pre>layerInfo = {{ lyr.get('layerInfo') | json }}</pre>
                             </div>
                         </div>

--- a/lib/core/time/maps.js
+++ b/lib/core/time/maps.js
@@ -127,7 +127,7 @@ function TileLoadListener(tileStatusCallback) {
 }
 
 function filterVectorLayer(layer, range) {
-    var timeAttr = layer.get('layerInfo').timeAttribute, l_features = layer.get('features');
+    var timeAttr = layer.get('layerInfo') ? layer.get('layerInfo').timeAttribute : undefined, l_features = layer.get('features');
     if (timeAttr === undefined || l_features === undefined) {
         return;
     }
@@ -155,8 +155,8 @@ function filterVectorLayer(layer, range) {
  * @param {array} features (opitonal)
  */
 function visitAllLayerFeatureTimes(layer, visitor, features) {
-    var startAtt = layer.get('layerInfo').timeAttribute;
-    var endAtt = layer.get('layerInfo').endTimeAttribute;
+    var startAtt = layer.get('layerInfo') ? layer.get('layerInfo').timeAttribute : undefined;
+    var endAtt = layer.get('layerInfo') ? layer.get('layerInfo').endTimeAttribute : undefined;
     var rangeGetter;
     features = features || layer.get('features') || layer.getSource().getFeatures();
     if (endAtt) {
@@ -183,8 +183,8 @@ function visitAllLayerFeatureTimes(layer, visitor, features) {
  * @returns {storytools.core.time.Range} range of features
  */
 exports.computeVectorRange = function(layer, features) {
-    var startAtt = layer.get('layerInfo').timeAttribute;
-    var endAtt = layer.get('layerInfo').endTimeAttribute;
+    var startAtt = layer.get('layerInfo') ? layer.get('layerInfo').timeAttribute : undefined;
+    var endAtt = layer.get('layerInfo') ? layer.get('layerInfo').endTimeAttribute : undefined;
     features = features || layer.get('features') || layer.getSource().getFeatures();
     return utils.computeRange(features, function(f) {
         return utils.createRange(f.get(startAtt), f.get(endAtt));

--- a/lib/core/time/maps.js
+++ b/lib/core/time/maps.js
@@ -127,7 +127,7 @@ function TileLoadListener(tileStatusCallback) {
 }
 
 function filterVectorLayer(layer, range) {
-    var timeAttr = layer.get('timeAttribute'), l_features = layer.get('features');
+    var timeAttr = layer.get('layerInfo').timeAttribute, l_features = layer.get('features');
     if (timeAttr === undefined || l_features === undefined) {
         return;
     }
@@ -155,8 +155,8 @@ function filterVectorLayer(layer, range) {
  * @param {array} features (opitonal)
  */
 function visitAllLayerFeatureTimes(layer, visitor, features) {
-    var startAtt = layer.get('timeAttribute');
-    var endAtt = layer.get('endTimeAttribute');
+    var startAtt = layer.get('layerInfo').timeAttribute;
+    var endAtt = layer.get('layerInfo').endTimeAttribute;
     var rangeGetter;
     features = features || layer.get('features') || layer.getSource().getFeatures();
     if (endAtt) {
@@ -183,8 +183,8 @@ function visitAllLayerFeatureTimes(layer, visitor, features) {
  * @returns {storytools.core.time.Range} range of features
  */
 exports.computeVectorRange = function(layer, features) {
-    var startAtt = layer.get('timeAttribute');
-    var endAtt = layer.get('endTimeAttribute');
+    var startAtt = layer.get('layerInfo').timeAttribute;
+    var endAtt = layer.get('layerInfo').endTimeAttribute;
     features = features || layer.get('features') || layer.getSource().getFeatures();
     return utils.computeRange(features, function(f) {
         return utils.createRange(f.get(startAtt), f.get(endAtt));
@@ -256,7 +256,7 @@ exports.MapController = function(options, timeControls) {
             var layer = layers.item(i);
             if ((layer instanceof ol.layer.Tile && layer.getSource() instanceof ol.source.TileWMS) ||
               (layer instanceof ol.layer.Image && layer.getSource() instanceof ol.source.ImageWMS)) {
-                if (layer.get('times')) {
+                if (layer.get('layerInfo') && layer.get('layerInfo').times) {
                     layer.getSource().updateParams({TIME: time});
                 }
             } else if (layer instanceof ol.layer.Vector) {

--- a/lib/edit/style/WFSDescribeFeatureType.js
+++ b/lib/edit/style/WFSDescribeFeatureType.js
@@ -38,7 +38,7 @@ exports.WFSDescribeFeatureType = function() {
             fields.push({name: el.name, type: el.type.localPart, typeNS: el.type.namespaceURI});
         }
         return {
-            timeAttr: timeAttr,
+            timeAttribute: timeAttr,
             featureNS: featureNS,
             geomType: geometryType,
             attributes: fields

--- a/lib/mapstory/MapConfig.js
+++ b/lib/mapstory/MapConfig.js
@@ -51,6 +51,15 @@ exports.MapConfig = function() {
             // old style GXP
             if (data.tools) {
                 data = this.transform(data);
+            } else {
+                for (var i=0, ii=data.map.layers.length; i<ii; ++i) {
+                    var layer = data.map.layers[i], layerInfo = layer.layerInfo;
+                    if (layerInfo) {
+                        if (storytools.core.time.utils.isRangeLike(layerInfo.times)) {
+                            layerInfo.times = new storytools.core.time.utils.Interval(layerInfo.times);
+                        }
+                    }
+                }
             }
             this.apply(data, mapManager);
         },

--- a/lib/mapstory/MapConfig.js
+++ b/lib/mapstory/MapConfig.js
@@ -4,17 +4,9 @@ exports.MapConfig = function() {
             id: layer.get('id'),
             title: layer.get('title')
         };
-        var times = layer.get('times');
-        if (times !== undefined) {
-            config.times = times;
-        }
         var layerInfo = layer.get('layerInfo');
         if (layerInfo !== undefined) {
             config.layerInfo = layerInfo;
-        }
-        var timeAttribute = layer.get('timeAttribute');
-        if (timeAttribute !== undefined) {
-            config.timeAttribute = timeAttribute;
         }
         var extent;
         if (layer instanceof ol.layer.Tile) {
@@ -134,7 +126,9 @@ exports.MapConfig = function() {
                             // TODO require dependency explicitly?
                             if (layer.capability) {
                                layerConfig.latlonBBOX = layer.capability.llbbox;
-                               layerConfig.times = storytools.core.time.maps.readCapabilitiesTimeDimensions(layer.capability, true);
+                               layerConfig.layerInfo = {
+                                   times: storytools.core.time.maps.readCapabilitiesTimeDimensions(layer.capability, true)
+                               };
                             }
                         }
                         layers.push(layerConfig);
@@ -175,9 +169,7 @@ exports.MapConfig = function() {
                         id: layer.id,
                         name: layer.id,
                         title: layer.title,
-                        times: layer.times,
-                        layerInfo: layer.layerInfo,
-                        timeAttribute: layer.timeAttribute
+                        layerInfo: layer.layerInfo
                     };
                     if (layer.singleTile === true) {
                         lyr = new ol.layer.Image(cfg);
@@ -204,7 +196,7 @@ exports.MapConfig = function() {
                             params: layer.params
                         }));
                     }
-                    if (layer.times && !layer.layerInfo) {
+                    if (layer.layerInfo && layer.layerInfo.times && !layer.layerInfo.attributes) {
                         /*jshint -W083 */
                         angular.bind({counter: i, layer: lyr}, function() {
                             var me = this;

--- a/lib/ng/core/pins/module.js
+++ b/lib/ng/core/pins/module.js
@@ -87,8 +87,10 @@
                 })
             })];
         this.storyPinsLayer = new ol.layer.Vector({
-            timeAttribute: 'start_time',
-            endTimeAttribute: 'end_time',
+            layerInfo: {
+                timeAttribute: 'start_time',
+                endTimeAttribute: 'end_time'
+            },
             source: new ol.source.Vector(),
             style: defaultStyle
         });
@@ -126,7 +128,7 @@
         var times = this.storyPins.map(function(p) {
             return storytools.core.utils.createRange(p.start_time, p.end_time);
         });
-        this.storyPinsLayer.set('times', times);
+        this.storyPinsLayer.set('layerInfo', angular.extend(this.storyPinsLayer.get('layerInfo') || {}, {times: times}));
         this.storyPinsLayer.set('features', features);
     };
 

--- a/lib/ng/core/time/services.js
+++ b/lib/ng/core/time/services.js
@@ -17,7 +17,7 @@
         // allow a map to be passed in
         if (!angular.isArray(layersWithTime)) {
             layersWithTime = layersWithTime.getLayers().getArray().filter(function(l) {
-                var times = l.get('times');
+                var times = l.get('layerInfo') ? l.get('layerInfo').times : undefined;
                 /*jshint eqnull:true */
                 return times != null;
             });
@@ -32,7 +32,7 @@
             }
         }
         layersWithTime.forEach(function(l) {
-            var times = l.get('times');
+            var times = l.get('layerInfo').times;
             var range;
             if (angular.isArray(times)) {
                 // an array of instants or extents

--- a/test/test-MapConfig.js
+++ b/test/test-MapConfig.js
@@ -4,6 +4,15 @@ var instance = new MapConfig();
 
 describe('MapConfig', function() {
 
+    it('should transform to Interval object', function() {
+        var data = JSON.parse('{"id":214,"map":{"center":[0,0],"projection":"EPSG:3857","zoom":3,"layers":[{"id":"foo","title":"My layer","layerInfo":{"geomType":"point","attributes": ["attr1", "attr2"],"timeAttribute":"attr1","times":{"start": 631152000000, "end": 1230768000000, "duration": "P1Y"}},"singleTile":false,"type":"WMS","url":"http://myserver","params":{"LAYERS":"x"}}]}}');
+        instance.read(data, {
+            mapid: 214,
+            map: new ol.Map({view: new ol.View()})
+        });
+        expect(data.map.layers[0].layerInfo.times.interval).toBe(31536000000);
+    });
+
     it('should convert extent, zoom and projection', function() {
         var mapManager = {
             mapid: 215

--- a/test/test-MapConfig.js
+++ b/test/test-MapConfig.js
@@ -23,10 +23,10 @@ describe('MapConfig', function() {
             id: 'foo',
             title: 'My layer',
             layerInfo: {
-                geomType: 'point'
+                geomType: 'point',
+                timeAttribute: 'attr1',
+                times: ['2001', '2002', '2003']
             },
-            times: ['2001', '2002', '2003'],
-            timeAttr: 'attr1',
             source: new ol.source.TileWMS({
                 url: 'http://myserver',
                 params: {
@@ -35,7 +35,7 @@ describe('MapConfig', function() {
             })
         }));
         var config = instance.write(mapManager);
-        var expected = '{"id":216,"map":{"center":[0,0],"projection":"EPSG:3857","zoom":3,"layers":[{"id":"foo","title":"My layer","times":["2001","2002","2003"],"layerInfo":{"geomType":"point"},"singleTile":false,"type":"WMS","url":"http://myserver","params":{"LAYERS":"x"}}]}}';
+        var expected = '{"id":216,"map":{"center":[0,0],"projection":"EPSG:3857","zoom":3,"layers":[{"id":"foo","title":"My layer","layerInfo":{"geomType":"point","timeAttribute":"attr1","times":["2001","2002","2003"]},"singleTile":false,"type":"WMS","url":"http://myserver","params":{"LAYERS":"x"}}]}}';
         expect(JSON.stringify(config)).toBe(expected);
     });
 
@@ -48,10 +48,10 @@ describe('MapConfig', function() {
             id: 'foo',
             title: 'My layer',
             layerInfo: {
-                geomType: 'point'
+                geomType: 'point',
+                timeAttr: 'attr1',
+                times: ['2001', '2002', '2003']
             },
-            times: ['2001', '2002', '2003'],
-            timeAttr: 'attr1',
             source: new ol.source.ImageWMS({
                 url: 'http://myserver',
                 params: {
@@ -60,7 +60,7 @@ describe('MapConfig', function() {
             })
         }));
         var config = instance.write(mapManager);
-        var expected = '{"id":217,"map":{"center":[0,0],"projection":"EPSG:3857","zoom":3,"layers":[{"id":"foo","title":"My layer","times":["2001","2002","2003"],"layerInfo":{"geomType":"point"},"singleTile":true,"type":"WMS","url":"http://myserver","params":{"LAYERS":"x"}}]}}';
+        var expected = '{"id":217,"map":{"center":[0,0],"projection":"EPSG:3857","zoom":3,"layers":[{"id":"foo","title":"My layer","layerInfo":{"geomType":"point","timeAttr":"attr1","times":["2001","2002","2003"]},"singleTile":true,"type":"WMS","url":"http://myserver","params":{"LAYERS":"x"}}]}}';
         expect(JSON.stringify(config)).toBe(expected);
     });
 
@@ -74,6 +74,19 @@ describe('MapConfig', function() {
         }));
         var config = instance.write(mapManager);
         var expected = '{"id":218,"map":{"center":[0,0],"projection":"EPSG:3857","zoom":3,"layers":[{"type":"OSM"}]}}';
+        expect(JSON.stringify(config)).toBe(expected);
+    });
+
+    it('should convert an MapQuest layer', function() {
+        var mapManager = {
+            mapid: 219
+        };
+        mapManager.map = new ol.Map({view: new ol.View({center: [0,0], zoom: 3})});
+        mapManager.map.addLayer(new ol.layer.Tile({
+            source: new ol.source.MapQuest({layer: 'sat'})
+        }));
+        var config = instance.write(mapManager);
+        var expected = '{"id":219,"map":{"center":[0,0],"projection":"EPSG:3857","zoom":3,"layers":[{"type":"MapQuest","layer":"sat"}]}}';
         expect(JSON.stringify(config)).toBe(expected);
     });
 

--- a/test/test-maps.js
+++ b/test/test-maps.js
@@ -59,7 +59,9 @@ describe("test maps", function() {
         beforeEach(function() {
             layer = new ol.layer.Vector({
                 source: new ol.source.Vector(),
-                timeAttribute: "time"
+                layerInfo: {
+                    timeAttribute: "time"
+                }
             });
 
             features = [
@@ -81,7 +83,9 @@ describe("test maps", function() {
             expect(range.end).toBe(1000);
         });
         it('when empty endTimeAttribute', function() {
-            layer.set('endTimeAttribute', 'endTime');
+            var layerInfo = layer.get('layerInfo');
+            layerInfo.endTimeAttribute = 'endTime';
+            layer.set('layerInfo', layerInfo);
             range = maps.computeVectorRange(layer);
             expect(range.start).toBe(1000);
             expect(range.end).toBe(1000);
@@ -95,7 +99,9 @@ describe("test maps", function() {
             expect(range.end).toBe(1000);
         });
         it('with single endAttribute', function() {
-            layer.set('endTimeAttribute', 'endTime');
+            var layerInfo = layer.get('layerInfo');
+            layerInfo.endTimeAttribute = 'endTime';
+            layer.set('layerInfo', layerInfo);
             layer.set('features', [new ol.Feature({endTime: 678})]);
             range = maps.computeVectorRange(layer);
             expect(range.start).toBe(678);
@@ -123,8 +129,10 @@ describe("test maps", function() {
         beforeEach(function() {
             layer = new ol.layer.Vector({
                 source: new ol.source.Vector(),
-                timeAttribute: "time",
-                endTimeAttribute: "endTime"
+                layerInfo: {
+                    timeAttribute: "time",
+                    endTimeAttribute: "endTime"
+                }
             });
             var id = 1;
             features = [
@@ -136,7 +144,9 @@ describe("test maps", function() {
             layer.set('features', features);
         });
         it('filters instants', function() {
-            layer.set('endTimeAttribute', null);
+            var layerInfo = layer.get('layerInfo');
+            layerInfo.endTimeAttribute = null;
+            layer.set('layerInfo', layerInfo);
             // range before everything
             maps.filterVectorLayer(layer, {start:500, end: 501});
             expect(ids()).toEqual([]);

--- a/test/test-timeServices.js
+++ b/test/test-timeServices.js
@@ -15,12 +15,12 @@ describe('test time services', function() {
             Array.prototype.slice.call(arguments).forEach(function(data) {
                 layers.push({
                     get: function() {
-                        return data;
+                        return {times: data};
                     }
                 });
             });
             return layers;
-        };
+        }
         beforeEach(function() {
 
             inject(function($injector) {


### PR DESCRIPTION
We now have 2 occurrences: in the layerInfo and as a separate entry on the layer.
I'd say we only put it in layerInfo?
And we might as well move times in there as well?