### PR TITLE
font family not taken into account anymore

### DIFF
--- a/lib/edit/style/SLDStyleConverter.js
+++ b/lib/edit/style/SLDStyleConverter.js
@@ -214,6 +214,16 @@ exports.SLDStyleConverter = function() {
             };
         },
         createTextSymbolizer: function(style) {
+            var fontFamily;
+            if (style.label.fontFamily === 'serif') {
+                fontFamily  = 'Serif';
+            } else if (style.label.fontFamily === 'sans-serif') {
+                fontFamily = 'SansSerif';
+            } else if (style.label.fontFamily === 'cursive') {
+                fontFamily = 'Comic Sans MS';
+            } else if (style.label.fontFamily === 'monospace') {
+                fontFamily = 'Courier New';
+            }
             return {
                 name: {
                     localPart: 'TextSymbolizer',
@@ -243,7 +253,7 @@ exports.SLDStyleConverter = function() {
                     font: {
                         cssParameter: [{
                                 name: 'font-family',
-                                content: [style.label.fontFamily]
+                                content: [fontFamily]
                             }, {
                                 name: 'font-size',
                                 content: [String(style.label.fontSize)]

--- a/test/test-SLDStyleConverter.js
+++ b/test/test-SLDStyleConverter.js
@@ -105,7 +105,7 @@ describe('SLDStyleConverter', function() {
             "label": {
                 "attribute": "foo",
                 "fillColor": "#000000",
-                "fontFamily": "Serif",
+                "fontFamily": "serif",
                 "fontSize": 10,
                 "fontStyle": "normal",
                 "fontWeight": "normal"


### PR DESCRIPTION
It is outputted in the SLD but does not have any visual effect anymore

```
<sld:StyledLayerDescriptor xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ogc="http://www.opengis.net/ogc" version="1.0.0"><sld:NamedLayer><sld:Name>states</sld:Name><sld:UserStyle><sld:FeatureTypeStyle><sld:Rule><sld:PolygonSymbolizer><sld:Fill><sld:CssParameter name="fill">#FF0000</sld:CssParameter><sld:CssParameter name="fill-opacity">1</sld:CssParameter></sld:Fill><sld:Stroke><sld:CssParameter name="stroke">#000000</sld:CssParameter><sld:CssParameter name="stroke-width">1</sld:CssParameter><sld:CssParameter name="stroke-opacity">1</sld:CssParameter><sld:CssParameter name="stroke-dasharray"/></sld:Stroke></sld:PolygonSymbolizer><sld:TextSymbolizer><sld:Label><ogc:PropertyName>STATE_NAME</ogc:PropertyName></sld:Label><sld:Font><sld:CssParameter name="font-family">cursive</sld:CssParameter><sld:CssParameter name="font-size">10</sld:CssParameter><sld:CssParameter name="font-style">normal</sld:CssParameter><sld:CssParameter name="font-weight">normal</sld:CssParameter></sld:Font><sld:LabelPlacement><sld:LinePlacement/></sld:LabelPlacement><sld:Halo><sld:Radius>1</sld:Radius><sld:Fill><sld:CssParameter name="fill">#FFFFFF</sld:CssParameter></sld:Fill></sld:Halo><sld:Fill><sld:CssParameter name="fill">#000000</sld:CssParameter></sld:Fill><sld:VendorOption name="maxDisplacement">40</sld:VendorOption><sld:VendorOption name="autoWrap">40</sld:VendorOption><sld:VendorOption name="spaceAround">0</sld:VendorOption><sld:VendorOption name="followLine">false</sld:VendorOption><sld:VendorOption name="group">yes</sld:VendorOption><sld:VendorOption name="goodnessOfFit">0.2</sld:VendorOption><sld:VendorOption name="conflictResolution">true</sld:VendorOption></sld:TextSymbolizer></sld:Rule></sld:FeatureTypeStyle></sld:UserStyle></sld:NamedLayer></sld:StyledLayerDescriptor>
```