### PR TITLE
we have annotations where start > end

### DIFF
--- a/examples/common.js
+++ b/examples/common.js
@@ -148,6 +148,9 @@
                     }
                 });
                 var annotationsURL = options.url.replace('/data','/annotations');
+                if (annotationsURL.slice(-1) === '/') {
+                    annotationsURL = annotationsURL.slice(0, -1);
+                }
                 var annotationsLoad = $http.get(annotationsURL);
                 $q.all([mapLoad, annotationsLoad]).then(function(values) {
                     var geojson = values[1].data;
@@ -169,7 +172,7 @@
             var path = $location.path();
             if (path === '/new') {
                 self.loadMap();
-            } else if (path.indexOf('/local') == 0) {
+            } else if (path.indexOf('/local') === 0) {
                 self.loadMap({id: /\d+/.exec(path)});
             } else {
                 self.loadMap({url: path});

--- a/lib/ng/core/pins/module.js
+++ b/lib/ng/core/pins/module.js
@@ -127,7 +127,11 @@
             }
         });
         var times = this.storyPins.map(function(p) {
-            return storytools.core.utils.createRange(p.start_time, p.end_time);
+            if (p.start_time > p.end_time) {
+                return storytools.core.utils.createRange(p.end_time, p.start_time);
+            } else {
+                return storytools.core.utils.createRange(p.start_time, p.end_time);
+            }
         });
         this.storyPinsLayer.set('layerInfo', angular.extend(this.storyPinsLayer.get('layerInfo') || {}, {times: times}));
         this.storyPinsLayer.set('features', features);


### PR DESCRIPTION
@ischneider should we handle them more silently? We currently throw and error.

An example is mapstory map number 1193

```
StoryPin {appearance: "tr-tr?", title: "1683", content: "William Penn's colony erects a brewery at Peonshury near Bristol, Pennsylvania. ", start_time: -9043747200000, end_time: -9056793600000…}appearance: "tr-tr?"content: "William Penn's colony erects a brewery at Peonshury near Bristol, Pennsylvania. "end_time: -9056793600000id: 16073in_map: truein_timeline: truestart_time: -9043747200000the_geom: nulltitle: "1683"
```

```
throw new Error('start > end');
```