### PR TITLE
set tileGrid parameters from WMS-C GetCapabilities

### DIFF
--- a/lib/core/time/maps.js
+++ b/lib/core/time/maps.js
@@ -44,14 +44,9 @@ exports.readCapabilitiesTimeDimensions = function(caps, openlayers2) {
         }
     } else {
         // @todo need to make layer scanning recursive?
-        caps.Capability.Layer.Layer.forEach(function(lyr) {
-            if (typeof lyr.Dimension !== 'undefined') {
-                var dims = lyr.Dimension.filter(function(dim) {
-                    return dim.name.toLowerCase() === 'time';
-                });
-                if (dims.length) {
-                    dimensions[lyr.Name] = parse(dims[0].values);
-                }
+        caps.value.capability.layer.layer.forEach(function(lyr) {
+            if (lyr.dimension) {
+              dimensions[lyr.name] = parse(lyr.extent[0].value);
             }
         });
     }

--- a/lib/ng/core/ogc/module.js
+++ b/lib/ng/core/ogc/module.js
@@ -277,12 +277,36 @@
             params: {
               'REQUEST': request,
               'SERVICE': service,
-              'VERSION': '1.3.0'
+              'VERSION': '1.1.1',
+              'TILED': true
             }
           }).success(function(data) {
-            var caps = new ol.format.WMSCapabilities().read(data);
-            storyLayer.set('latlonBBOX',
-                caps.Capability.Layer.Layer[0].EX_GeographicBoundingBox);
+            var context = new owsjs.Jsonix.Context([
+                owsjs.mappings.WMSC_1_1_1
+            ]);
+            var unmarshaller = context.createUnmarshaller();
+            var caps = unmarshaller.unmarshalString(data);
+            var layer = caps.value.capability.layer;
+            storyLayer.set('latlonBBOX', [
+              parseFloat(layer.latLonBoundingBox.minx),
+              parseFloat(layer.latLonBoundingBox.miny),
+              parseFloat(layer.latLonBoundingBox.maxx),
+              parseFloat(layer.latLonBoundingBox.maxy)
+            ]);
+            var tileSets = caps.value.capability.vendorSpecificCapabilities.tileSet;
+            for (var i=0, ii=tileSets.length; i<ii; ++i) {
+                if (tileSets[i].srs === 'EPSG:900913') {
+                    storyLayer.set('resolutions', tileSets[i].resolutions.split(' '));
+                    var bbox = tileSets[i].boundingBox;
+                    storyLayer.set('bbox', [
+                        parseFloat(bbox.minx),
+                        parseFloat(bbox.miny),
+                        parseFloat(bbox.maxx),
+                        parseFloat(bbox.maxy)
+                    ]);
+                    break;
+                }
+            }
             var found = storytools.core.time.maps.readCapabilitiesTimeDimensions(caps);
             var name = storyLayer.get('name');
             if (name in found) {

--- a/lib/owsjs/index.js
+++ b/lib/owsjs/index.js
@@ -14,6 +14,7 @@ exports.mappings.GML_3_1_1 = require('../../bower_components/ogc-schemas/scripts
 exports.mappings.WFS_1_1_0 = require('../../bower_components/ogc-schemas/scripts/lib/WFS_1_1_0.js').WFS_1_1_0;
 exports.mappings.WPS_1_0_0 = require('../../bower_components/ogc-schemas/scripts/lib/WPS_1_0_0.js').WPS_1_0_0;
 exports.mappings.XSD_1_0 = require('../../bower_components/w3c-schemas/scripts/lib/XSD_1_0.js').XSD_1_0;
+exports.mappings.WMSC_1_1_1 = require('../../bower_components/ogc-schemas/scripts/lib/WMSC_1_1_1.js').WMSC_1_1_1;
 
 // modify the JSONIX mapping to add the GeoServer specific VendorOption
 exports.mappings.SLD_1_0_0.tis.push({

--- a/test/test-maps.js
+++ b/test/test-maps.js
@@ -5,18 +5,20 @@ describe("test maps", function() {
     it("readCapabilitiesTimeDimensions works", function() {
         function makeCaps(config) {
             return {
-                Capability: {
-                    Layer: {
-                        Layer: Object.getOwnPropertyNames(config).map(function(lyr) {
-                            return {Name: lyr, Dimension: [{name: 'time', values: config[lyr]}]};
-                        })
+                value: {
+                    capability: {
+                        layer: {
+                            layer: Object.getOwnPropertyNames(config).map(function(lyr) {
+                                return {name: lyr, dimension: {}, extent: [{value: config[lyr]}]};
+                            })
+                        }
                     }
                 }
             };
         }
         function expectData(args) {
             return expect(maps.readCapabilitiesTimeDimensions(makeCaps(args)));
-        };
+        }
         function read(values) {
             return maps.readCapabilitiesTimeDimensions(makeCaps({data:values})).data;
         }


### PR DESCRIPTION
This is a follow-up from #208 

Once the WMS-C parser is in JSONIX we will need to parse the resolutions array and the extent and set that in the layer config to make use of the custom tileGrid

This also involves using WMS 1.1.1 GetCapabilities parsing instead of 1.3.0 as we have now.