### PR TITLE
Persist Style in Style Editor

### DIFF
--- a/lib/ng/edit/style/controllers/controllers.js
+++ b/lib/ng/edit/style/controllers/controllers.js
@@ -61,11 +61,6 @@
                 var style;
                 var jsonStyle = getSavedLayerStyle($scope.layer);
 
-                if (goog.isDefAndNotNull(jsonStyle)) {
-                  style = stStyleTypes.createStyle(jsonStyle);
-                  return style;
-                }
-
                 if (styleTyle.name in styles) {
                     style = styles[styleTyle.name];
                 } else {
@@ -77,6 +72,11 @@
                     }
                     style = stStyleTypes.createStyle(styleType[0]);
                 }
+
+                if (goog.isDefAndNotNull(jsonStyle)) {
+                  goog.object.extend(style, jsonStyle);
+                }
+
                 return style;
             }
 

--- a/lib/ng/edit/style/controllers/controllers.js
+++ b/lib/ng/edit/style/controllers/controllers.js
@@ -3,9 +3,25 @@
 
     var module = angular.module('storytools.edit.style.controllers', []);
 
-    module.controller('styleEditorController', 
+    module.controller('styleEditorController',
         function($scope, stStyleTypes, stStyleChoices, stLayerClassificationService, stStyleRuleBuilder) {
             var styles = {};
+
+            function getSavedLayerStyle(layer) {
+              var layerStyleJson = null;
+              var savedLayerStyle = null;
+              var chapter_index = window.config.chapter_index;
+              // if json style exists in the chapter config, grab it
+              if (goog.isDefAndNotNull(layer.get('metadata').jsonstyle)) {
+                layerStyleJson = layer.get('metadata').jsonstyle;
+              // or if it exists in the temporary style store, grab that one
+              } else if(goog.isDefAndNotNull(window.config.stylestore) &&
+                        goog.isDefAndNotNull(chapter_index) &&
+                        goog.isDefAndNotNull(window.config.stylestore[chapter_index][layer.get('metadata').name])) {
+                layerStyleJson = window.config.stylestore[chapter_index][layer.get('metadata').name];
+              }
+              return layerStyleJson;
+            }
 
             function promptClassChange() {
                 // @todo should check for rule edits?
@@ -31,6 +47,7 @@
                 $scope.layer = layer;
                 $scope.styleTypes = stStyleTypes.getTypes(layer);
                 if ($scope.styleTypes.length > 0) {
+                    var styleTest = getSavedLayerStyle(layer);
                     setActiveStyle($scope.styleTypes[0]);
                 }
             }
@@ -42,6 +59,12 @@
 
             function getStyle(styleTyle) {
                 var style;
+                var jsonStyle = getSavedLayerStyle($scope.layer);
+
+                if (goog.isDefAndNotNull(jsonStyle)) {
+                  style = stStyleTypes.createStyle(jsonStyle);
+                  return style;
+                }
 
                 if (styleTyle.name in styles) {
                     style = styles[styleTyle.name];

--- a/lib/ng/edit/style/controllers/controllers.js
+++ b/lib/ng/edit/style/controllers/controllers.js
@@ -47,7 +47,6 @@
                 $scope.layer = layer;
                 $scope.styleTypes = stStyleTypes.getTypes(layer);
                 if ($scope.styleTypes.length > 0) {
-                    var styleTest = getSavedLayerStyle(layer);
                     setActiveStyle($scope.styleTypes[0]);
                 }
             }

--- a/lib/ng/edit/style/services/styleTypes.js
+++ b/lib/ng/edit/style/services/styleTypes.js
@@ -198,10 +198,10 @@
             },
             createStyle: function(styleType) {
                 var base = {
-                    symbol: defaultSymbol,
-                    stroke: defaultStroke,
+                    symbol: styleType.symbol || defaultSymbol,
+                    stroke: styleType.stroke || defaultStroke,
                     label: defaultLabel,
-                    typeName: styleType.name
+                    typeName: styleType.typeName || styleType.name
                 };
                 var style = angular.extend({}, angular.copy(base), styleType.prototype);
                 if ('classify' in style) {


### PR DESCRIPTION
When a user revisits the style editor, it will retain the styles that were previously applied, assuming the layer contains a `jsonstyle` member in its metadata containing the style information to be applied; or a temporary `stylestore` object exists in `window.config`. These have been implemented in MapStory Composer. 