### PR TITLE
Add stroke and symbol to style rather than extending object.

### DIFF
--- a/lib/ng/edit/style/controllers/controllers.js
+++ b/lib/ng/edit/style/controllers/controllers.js
@@ -73,7 +73,8 @@
                 }
 
                 if (goog.isDefAndNotNull(jsonStyle)) {
-                  goog.object.extend(style, jsonStyle);
+                  style.symbol = jsonStyle.symbol;
+                  style.stroke = jsonStyle.stroke;
                 }
 
                 return style;

--- a/lib/ng/edit/style/services/styleTypes.js
+++ b/lib/ng/edit/style/services/styleTypes.js
@@ -201,7 +201,7 @@
                     symbol: styleType.symbol || defaultSymbol,
                     stroke: styleType.stroke || defaultStroke,
                     label: defaultLabel,
-                    typeName: styleType.typeName || styleType.name
+                    typeName: styleType.name
                 };
                 var style = angular.extend({}, angular.copy(base), styleType.prototype);
                 if ('classify' in style) {


### PR DESCRIPTION
In order to persist styles in the style editor, the code was initially written to extend the style being passed to the editor using the layer's style. This was overwriting necessary attributes contained in the original style object.