### PR TITLE
Declare `styleType` to prevent errors.

### DIFF
--- a/lib/ng/edit/style/directives/directives.js
+++ b/lib/ng/edit/style/directives/directives.js
@@ -15,6 +15,7 @@
                 link: function(scope, element, attrs) {
                     // @todo bleck - grabbing the layer from the parent
                     // should be replaced with something more explicit
+                    var styleType = null;
                     scope.layer = scope.$parent.layer;
                     if (scope.$parent.activeStyle) {
                       styleType = scope.$parent.activeStyle.typeName;


### PR DESCRIPTION
`styleType` isn't declared, which results in an error if the `use strict` directive is present.