### PR TITLE
Add styleType var declaration to build file

### DIFF
--- a/dist/story-tools-edit-ng.js
+++ b/dist/story-tools-edit-ng.js
@@ -613,7 +613,7 @@
                     // should be replaced with something more explicit
                     scope.layer = scope.$parent.layer;
                     if (scope.$parent.activeStyle) {
-                      styleType = scope.$parent.activeStyle.typeName;
+                      var styleType = scope.$parent.activeStyle.typeName;
                       scope.hideStrokeWidth = styleType === 'graduated-line' ? true : false;
                     }
                     scope.$watch(function() {

--- a/dist/story-tools-edit.js
+++ b/dist/story-tools-edit.js
@@ -703,6 +703,8 @@ exports.styleStorageService = function() {
         if (chapterLayers[i].name === layerName &&
             isDefAndNotNull(chapterLayers[i]['jsonstyle'])) {
           layerStyleJson = chapterLayers[i]['jsonstyle'];
+            isDefAndNotNull(chapterLayers[i].jsonstyle)) {
+          layerStyleJson = chapterLayers[i].jsonstyle;
         }
       }
     // or if it exists in the temporary style store, grab that one

--- a/lib/edit/style/styleStorageService.js
+++ b/lib/edit/style/styleStorageService.js
@@ -36,6 +36,8 @@ exports.styleStorageService = function() {
         if (chapterLayers[i].name === layerName &&
             isDefAndNotNull(chapterLayers[i]['jsonstyle'])) {
           layerStyleJson = chapterLayers[i]['jsonstyle'];
+            isDefAndNotNull(chapterLayers[i].jsonstyle)) {
+          layerStyleJson = chapterLayers[i].jsonstyle;
         }
       }
     // or from the layer

--- a/lib/ng/edit/style/directives/directives.js
+++ b/lib/ng/edit/style/directives/directives.js
@@ -15,10 +15,9 @@
                 link: function(scope, element, attrs) {
                     // @todo bleck - grabbing the layer from the parent
                     // should be replaced with something more explicit
-                    var styleType = null;
                     scope.layer = scope.$parent.layer;
                     if (scope.$parent.activeStyle) {
-                      styleType = scope.$parent.activeStyle.typeName;
+                      var styleType = scope.$parent.activeStyle.typeName;
                       scope.hideStrokeWidth = styleType === 'graduated-line' ? true : false;
                     }
                     scope.$watch(function() {


### PR DESCRIPTION
This PR:

- adds var declarations for `strict` js
- adds dot notation to appease the linter 