### PR TITLE
Update karma-phantomjs-launcher version and fix moment filepath

### DIFF
--- a/dist/story-tools-core.js
+++ b/dist/story-tools-core.js
@@ -537,7 +537,7 @@ exports.TimeLine = function(id, model) {
 },{"./utils":9,"vis/lib/timeline/Timeline":26}],5:[function(require,module,exports){
 /*jshint loopfunc: true */
 var utils = require('./utils');
-var moment = require('vis/node_modules/moment');
+var moment = require('moment');
 
 /**
  * Read the provide ol3 WMS capabilities document
@@ -816,7 +816,7 @@ exports.MapController = function(options, timeControls) {
     timeControls.on('rangeChange', updateLayers);
 };
 
-},{"./utils":9,"vis/node_modules/moment":45}],6:[function(require,module,exports){
+},{"./utils":9,"moment":18}],6:[function(require,module,exports){
 var utils = require('./utils');
 var BoxModel = require('./boxes').BoxModel;
 
@@ -1105,7 +1105,7 @@ exports.TimeSlider = function(id, model) {
 };
 
 },{}],9:[function(require,module,exports){
-var moment = require('vis/node_modules/moment');
+var moment = require('moment');
 
 /**
  * Get the number of milliseconds from the provided arg.
@@ -1492,11 +1492,7 @@ exports.createOffsetter = function(intervalOrDuration) {
     }
 };
 
-},{"vis/node_modules/moment":45}],10:[function(require,module,exports){
-'use strict';
-
-var util = require('./util');
-var Queue = require('./Queue');
+},{"moment":18}],10:[function(require,module,exports){
 
 /**
  * DataSet

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -257,11 +257,17 @@ gulp.task('tdd', ['test'], function() {
     gulp.watch('test/*', ['karma']);
 });
 
-gulp.task('test', ['clean', 'karma']);
-
 gulp.task('default', ['clean', 'lint', 'test', 'minify']);
 
 gulp.task('develop', ['connect', 'watch']);
+
+gulp.task('test', ['lint', 'bundleEditNg', 'lessEdit', 'bundleEditTemplates'], function() {
+    gulp.start('bundleCore');
+    gulp.start('bundleOwsjsLibs');
+    gulp.start('bundleMapstoryLibs');
+    gulp.start('bundleEdit');
+    gulp.start('testsBundle');
+});
 
 gulp.task('watch', ['lint', 'bundleEditNg', 'lessEdit', 'bundleEditTemplates'], function() {
     // enable watch mode and start watchify tasks

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -259,7 +259,7 @@ gulp.task('tdd', ['test'], function() {
 
 gulp.task('test', ['clean', 'karma']);
 
-gulp.task('default', ['clean', 'lint', 'test', 'minify', 'docs']);
+gulp.task('default', ['clean', 'lint', 'test', 'minify']);
 
 gulp.task('develop', ['connect', 'watch']);
 

--- a/lib/core/time/maps.js
+++ b/lib/core/time/maps.js
@@ -1,6 +1,6 @@
 /*jshint loopfunc: true */
 var utils = require('./utils');
-var moment = require('vis/node_modules/moment');
+var moment = require('moment');
 
 /**
  * Read the provide ol3 WMS capabilities document

--- a/lib/core/time/utils.js
+++ b/lib/core/time/utils.js
@@ -1,4 +1,4 @@
-var moment = require('vis/node_modules/moment');
+var moment = require('moment');
 
 /**
  * Get the number of milliseconds from the provided arg.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "karma-chrome-launcher": "~0.1.5",
     "karma-jasmine": "~0.2",
     "karma-sourcemap-loader": "~0.2",
-    "karma-phantomjs-launcher": "~0.1.4",
+    "karma-phantomjs-launcher": "~1.0.2",
     "vinyl-source-stream": "~1.0.0",
     "watchify": "2.1.1",
     "node-notifier": "~4.0.2",

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,5 +1,5 @@
 var utils = require('../lib/core/time/utils.js');
-var moment = require('vis/node_modules/moment');
+var moment = require('moment');
 
 /*
 NOTE - numeric values in these tests (and the API) are all milliseconds


### PR DESCRIPTION
This PR:

- updates the path to the `moment` module to fix an import error
- updates the version of `karma-phantomjs-launcher` being used so that tests can be run
- removes the `docs` step from the default Gulp process
