### PR TITLE
Add storage services to mapstory module

### DIFF
--- a/dist/story-tools-core-ng.js
+++ b/dist/story-tools-core-ng.js
@@ -181,70 +181,11 @@
       });
 }());
 (function() {
-  'use strict';
-   var module = angular.module('storytools.core.loading', [
-        'storytools.core.loading.directives'
-    ]);
-})();
-(function() {
     'use strict';
 
     var module = angular.module('storytools.core.mapstory', [
+      'storytools.core.mapstory.services'
     ]);
-
-    // @todo naive implementation on local storage for now
-    module.service('stMapConfigStore', function() {
-        function path(mapid) {
-            return '/maps/' + mapid;
-        }
-        function get(mapid) {
-            var saved = localStorage.getItem(path(mapid));
-            saved = (saved === null) ? {} : angular.fromJson(saved);
-            return saved;
-        }
-        function set(mapConfig) {
-            localStorage.setItem(path(mapConfig.id), angular.toJson(mapConfig));
-        }
-        function list() {
-            var maps = [];
-            var pattern = new RegExp('/maps/(\\d+)$');
-            Object.getOwnPropertyNames(localStorage).forEach(function(key) {
-                var match = pattern.exec(key);
-                if (match) {
-                    // name/title eventually
-                    maps.push({
-                        id: match[1]
-                    });
-                }
-            });
-            return maps;
-        }
-        function nextId() {
-            var lastId = 0;
-            var existing = list().map(function(m) {
-                return m.id;
-            });
-            existing.sort();
-            if (existing.length) {
-                lastId = parseInt(existing[existing.length - 1]);
-            }
-            return lastId + 1;
-        }
-        return {
-            listMaps: function() {
-                return list();
-            },
-            loadConfig: function(mapid) {
-                return get(mapid);
-            },
-            saveConfig: function(mapConfig) {
-                if (!angular.isDefined(mapConfig.id)) {
-                    mapConfig.id = nextId();
-                }
-                set(mapConfig);
-            }
-        };
-    });
 
 })();
 
@@ -2339,4 +2280,93 @@
             computeTicks: computeTicks
         };
     });
+})();
+
+(function() {
+    'use strict';
+    var module = angular.module('storytools.core.mapstory.localStorageSvc', []);
+
+    module.service('stLocalStorageSvc', ["$http", function($http) {
+        function path(mapid) {
+            return '/maps/' + mapid;
+        }
+
+        var localStorageHandler = {};
+
+        localStorageHandler.get = function(mapid) {
+            var saved = localStorage.getItem(path(mapid));
+            saved = (saved === null) ? {} : angular.fromJson(saved);
+            return saved;
+        };
+
+        localStorageHandler.set = function(mapConfig) {
+            localStorage.setItem(path(mapConfig.id), angular.toJson(mapConfig));
+        };
+
+        localStorageHandler.list = function() {
+            var maps = [];
+            var pattern = new RegExp('/maps/(\\d+)$');
+            Object.getOwnPropertyNames(localStorage).forEach(function(key) {
+                var match = pattern.exec(key);
+                if (match) {
+                    // name/title eventually
+                    maps.push({
+                        id: match[1]
+                    });
+                }
+            });
+            return maps;
+        };
+
+        localStorageHandler.nextId = function() {
+            var lastId = 0;
+            var existing = localStorageHandler.list().map(function(m) {
+                return m.id;
+            });
+            existing.sort();
+            if (existing.length) {
+                lastId = parseInt(existing[existing.length - 1]);
+            }
+            return lastId + 1;
+        };
+
+        return {
+            listMaps: function() {
+                return localStorageHandler.list();
+            },
+            loadConfig: function(mapid) {
+                return localStorageHandler.get(mapid);
+            },
+            saveConfig: function(mapConfig) {
+                if (!angular.isDefined(mapConfig.id)) {
+                    mapConfig.id = localStorageHandler.nextId();
+                }
+                localStorageHandler.set(mapConfig);
+            }
+        };
+    }]);
+})();
+
+(function() {
+    'use strict';
+
+    var module = angular.module('storytools.core.mapstory.remoteStorageSvc', []);
+
+    module.factory('stRemoteStorageSvc', ["$q", "$http", function($q, $http) {
+
+    this.save = function(map_config) {
+
+      // @TODO: Update window.config and save to server
+
+    };
+  }]);
+})();
+
+(function() {
+    'use strict';
+
+    var module = angular.module('storytools.core.mapstory.services', [
+        'storytools.core.mapstory.localStorageSvc',
+        'storytools.core.mapstory.remoteStorageSvc'
+    ]);
 })();

--- a/lib/ng/core/mapstory/module.js
+++ b/lib/ng/core/mapstory/module.js
@@ -2,60 +2,7 @@
     'use strict';
 
     var module = angular.module('storytools.core.mapstory', [
+      'storytools.core.mapstory.services'
     ]);
-
-    // @todo naive implementation on local storage for now
-    module.service('stMapConfigStore', function() {
-        function path(mapid) {
-            return '/maps/' + mapid;
-        }
-        function get(mapid) {
-            var saved = localStorage.getItem(path(mapid));
-            saved = (saved === null) ? {} : angular.fromJson(saved);
-            return saved;
-        }
-        function set(mapConfig) {
-            localStorage.setItem(path(mapConfig.id), angular.toJson(mapConfig));
-        }
-        function list() {
-            var maps = [];
-            var pattern = new RegExp('/maps/(\\d+)$');
-            Object.getOwnPropertyNames(localStorage).forEach(function(key) {
-                var match = pattern.exec(key);
-                if (match) {
-                    // name/title eventually
-                    maps.push({
-                        id: match[1]
-                    });
-                }
-            });
-            return maps;
-        }
-        function nextId() {
-            var lastId = 0;
-            var existing = list().map(function(m) {
-                return m.id;
-            });
-            existing.sort();
-            if (existing.length) {
-                lastId = parseInt(existing[existing.length - 1]);
-            }
-            return lastId + 1;
-        }
-        return {
-            listMaps: function() {
-                return list();
-            },
-            loadConfig: function(mapid) {
-                return get(mapid);
-            },
-            saveConfig: function(mapConfig) {
-                if (!angular.isDefined(mapConfig.id)) {
-                    mapConfig.id = nextId();
-                }
-                set(mapConfig);
-            }
-        };
-    });
 
 })();

--- a/lib/ng/core/mapstory/services/localStorageSvc.js
+++ b/lib/ng/core/mapstory/services/localStorageSvc.js
@@ -1,0 +1,64 @@
+(function() {
+    'use strict';
+    var module = angular.module('storytools.core.mapstory.localStorageSvc', []);
+
+    module.service('stLocalStorageSvc', ["$http", function($http) {
+        function path(mapid) {
+            return '/maps/' + mapid;
+        }
+
+        var localStorageHandler = {};
+
+        localStorageHandler.get = function(mapid) {
+            var saved = localStorage.getItem(path(mapid));
+            saved = (saved === null) ? {} : angular.fromJson(saved);
+            return saved;
+        };
+
+        localStorageHandler.set = function(mapConfig) {
+            localStorage.setItem(path(mapConfig.id), angular.toJson(mapConfig));
+        };
+
+        localStorageHandler.list = function() {
+            var maps = [];
+            var pattern = new RegExp('/maps/(\\d+)$');
+            Object.getOwnPropertyNames(localStorage).forEach(function(key) {
+                var match = pattern.exec(key);
+                if (match) {
+                    // name/title eventually
+                    maps.push({
+                        id: match[1]
+                    });
+                }
+            });
+            return maps;
+        };
+
+        localStorageHandler.nextId = function() {
+            var lastId = 0;
+            var existing = localStorageHandler.list().map(function(m) {
+                return m.id;
+            });
+            existing.sort();
+            if (existing.length) {
+                lastId = parseInt(existing[existing.length - 1]);
+            }
+            return lastId + 1;
+        };
+
+        return {
+            listMaps: function() {
+                return localStorageHandler.list();
+            },
+            loadConfig: function(mapid) {
+                return localStorageHandler.get(mapid);
+            },
+            saveConfig: function(mapConfig) {
+                if (!angular.isDefined(mapConfig.id)) {
+                    mapConfig.id = localStorageHandler.nextId();
+                }
+                localStorageHandler.set(mapConfig);
+            }
+        };
+    }]);
+})();

--- a/lib/ng/core/mapstory/services/remoteStorageSvc.js
+++ b/lib/ng/core/mapstory/services/remoteStorageSvc.js
@@ -1,0 +1,14 @@
+(function() {
+    'use strict';
+
+    var module = angular.module('storytools.core.mapstory.remoteStorageSvc', []);
+
+    module.factory('stRemoteStorageSvc', function($q, $http) {
+
+    this.save = function(map_config) {
+
+      // @TODO: Update window.config and save to server
+
+    };
+  });
+})();

--- a/lib/ng/core/mapstory/services/services.js
+++ b/lib/ng/core/mapstory/services/services.js
@@ -1,0 +1,8 @@
+(function() {
+    'use strict';
+
+    var module = angular.module('storytools.core.mapstory.services', [
+        'storytools.core.mapstory.localStorageSvc',
+        'storytools.core.mapstory.remoteStorageSvc'
+    ]);
+})();


### PR DESCRIPTION
This is some scaffolding work. I'm breaking the `mapstory` ng module into several services that get bundled into `storytools.core.mapstory`, beginning with the local and remote storage services. The remote storage service isn't finished yet. For now it's included as a placeholder. I also plan on moving the style storage service out of the core Node library and into the mapstory directory to also be wrapped into the module, since it won't be used outside of a browser context. 