### PR TITLE
Allow timeline to be updated..

### DIFF
--- a/lib/ng/core/time/services.js
+++ b/lib/ng/core/time/services.js
@@ -143,11 +143,9 @@
         pinsLayer.on('change:features', function() {
             maybeCreateTimeControls(function() {
                 var range = computeTicks(MapManager.storyMap);
-                if (range.length) {
+                if (range.length >= 0) {
                     return {
-                        storyLayers: MapManager.storyMap.getStoryLayers().getArray(),
                         annotations: pinsLayer.get("features"),
-                        boxes: boxesLayer.get("features"),
                         data: range
                     };
                 }
@@ -157,11 +155,10 @@
         boxesLayer.on('change:features', function() {
             maybeCreateTimeControls(function() {
                 var range = computeTicks(MapManager.storyMap);
-                if (range.length) {
+                if (range.length >= 0) {
                     return {
-                        annotations: pinsLayer.get("features"),
-                        data: range,
-                        boxes: boxesLayer.get("features")
+                        boxes: boxesLayer.get("features"),
+                        data: range
                     };
                 }
             });


### PR DESCRIPTION
Allows timeline to be updated when there are no storylayers and you add/remove boxes and annotations #243

The issue can be recreated by using the storystools composer:
1. Add a storypin or box
2. Notice the timeline appears
3. Remove the storypin or box
4. Notice the timeline isn't updated to reflect the removal feature