### PR TITLE
Update slider range to account for async behavior

### DIFF
--- a/dist/story-tools-core.js
+++ b/dist/story-tools-core.js
@@ -1263,6 +1263,13 @@ exports.TimeSlider = function(id, model) {
                 });
                 initialized = true;
             }
+        } else {
+          slider.noUiSlider.updateOptions({
+              range: {
+                min: 0,
+                max: model.getSteps() - 1
+              }
+          }, true);
         }
 
     }

--- a/lib/core/time/slider.js
+++ b/lib/core/time/slider.js
@@ -80,6 +80,13 @@ exports.TimeSlider = function(id, model) {
                 });
                 initialized = true;
             }
+        } else {
+          slider.noUiSlider.updateOptions({
+              range: {
+                min: 0,
+                max: model.getSteps() - 1
+              }
+          }, true);
         }
 
     }


### PR DESCRIPTION
Story-tools updates the time slider range asynchronously as layers are loaded. This PR ensures that the slider gets updated with the most current range.

Resolves https://github.com/MapStory/mapstory/issues/626