### PR TITLE
103 label outlines

### DIFF
--- a/lib/edit/style/SLDStyleConverter.js
+++ b/lib/edit/style/SLDStyleConverter.js
@@ -197,7 +197,8 @@ exports.SLDStyleConverter = function() {
             } else if (styleFontFamily === 'monospace') {
                 fontFamily = 'Courier New';
             }
-            return {
+
+            var styleObj = {
                 name: {
                     localPart: 'TextSymbolizer',
                     namespaceURI: "http://www.opengis.net/sld"
@@ -208,17 +209,6 @@ exports.SLDStyleConverter = function() {
                                 name: 'fill',
                                 content: [style.label.fillColor]
                             }]
-                    },
-                    halo: {
-                        fill: {
-                            cssParameter: [{
-                                name: 'fill',
-                                content: ['#FFFFFF']
-                            }]
-                        },
-                        radius: {
-                            content: ['1']
-                        }
                     },
                     labelPlacement: {
                         linePlacement: {}
@@ -273,6 +263,29 @@ exports.SLDStyleConverter = function() {
                     }]
                 }
             };
+
+            if (style.label.underlineText) {
+              styleObj.value.vendorOption.push({
+                name: 'underlineText',
+                content: 'true'
+              })
+            }
+
+            if (style.label.halo) {
+              styleObj.value.halo = {
+                fill: {
+                  cssParameter: [{
+                    name: 'fill',
+                    content: ['#FFFFFF']
+                  }]
+                },
+                radius: {
+                  content: ['1']
+                }
+              };
+            }
+
+            return styleObj;
         },
         convertJSON: function(style, layerName) {
             var result = {

--- a/lib/edit/style/SLDStyleConverter.js
+++ b/lib/edit/style/SLDStyleConverter.js
@@ -192,10 +192,8 @@ exports.SLDStyleConverter = function() {
                 fontFamily  = 'Serif';
             } else if (styleFontFamily === 'sans-serif') {
                 fontFamily = 'SansSerif';
-            } else if (styleFontFamily === 'cursive') {
-                fontFamily = 'Comic Sans MS';
             } else if (styleFontFamily === 'monospace') {
-                fontFamily = 'Courier New';
+                fontFamily = 'Monospaced';
             }
 
             var styleObj = {

--- a/lib/ng/edit/style/directives/directives.js
+++ b/lib/ng/edit/style/directives/directives.js
@@ -169,15 +169,23 @@
   });
   editorDirective("colorEditor", "color-editor.html");
   editorDirective("labelEditor", "label-editor.html", "label", function(scope) {
-    // @todo other options
     scope.styleModel = {
-      bold: scope.model.fontWeight == "bold",
-      italic: scope.model.fontStyle == "italic"
+      bold: scope.model.fontWeight === "bold",
+      italic: scope.model.fontStyle === "italic",
+      underline: scope.model.underlineText,
+      halo: scope.model.halo
     };
     scope.styleModelChange = function() {
+      console.log('Style model changed');
       scope.model.fontWeight = scope.styleModel.bold ? "bold" : "normal";
       scope.model.fontStyle = scope.styleModel.italic ? "italic" : "normal";
+      scope.model.underlineText = scope.styleModel.underline;
+      scope.model.halo = scope.styleModel.halo;
     };
+    scope.$watch('styleModel.bold', scope.styleModelChange);
+    scope.$watch('styleModel.italic', scope.styleModelChange);
+    scope.$watch('styleModel.underline', scope.styleModelChange);
+    scope.$watch('styleModel.halo', scope.styleModelChange);
   });
 
   // @todo break into pieces or make simpler

--- a/lib/ng/edit/style/services/styleChoices.js
+++ b/lib/ng/edit/style/services/styleChoices.js
@@ -18,7 +18,7 @@
                 'solid', 'dashed', 'dotted'
             ],
             fontFamily: [
-                'serif', 'sans-serif', 'cursive', 'monospace'
+                'serif', 'sans-serif', 'monospace'
             ],
             colorRamps: [
                 {

--- a/lib/ng/edit/style/services/styleTypes.js
+++ b/lib/ng/edit/style/services/styleTypes.js
@@ -29,6 +29,8 @@
         fontSize: 10,
         fontStyle: 'normal',
         fontWeight: 'normal',
+        underlineText: false,
+        halo: true,
         placement: 'point'
     };
 

--- a/lib/templates/edit/style/widgets/label-editor.html
+++ b/lib/templates/edit/style/widgets/label-editor.html
@@ -5,8 +5,8 @@
         <number-editor st-model="model" property="fontSize"></number-editor>
     </div>
     <div class="controls">
-        <div dropdown>
-            <button type="button" class="dropdown-toggle"   >
+        <div data-dropdown>
+            <button type="button" class="dropdown-toggle" data-toggle="dropdown">
                 {{model.fontFamily}} <span class="caret"></span>
             </button>
             <ul class="dropdown-menu scrollable-combo font-family" role="menu">

--- a/lib/templates/edit/style/widgets/label-editor.html
+++ b/lib/templates/edit/style/widgets/label-editor.html
@@ -15,11 +15,18 @@
         </div>
         <color-editor st-model="model" property="fillColor" ></color-editor>
         <div class="btn-group">
-            <button class="btn" ng-model="styleModel.bold" btn-checkbox ng-change="styleModelChange()"><strong>B</strong></button>
-            <button class="btn" ng-model="styleModel.underline" ng-change="styleModelChange()"><u>U</u></button>
-            <button class="btn" ng-model="styleModel.italic" btn-checkbox ng-change="styleModelChange()"><i>I</i></button>
-            <button class="btn" ng-model="styleModel.halo" ng-change="styleModelChange()">H</button>
-            <button class="btn" ng-model="styleModel.shadow" ng-change="styleModelChange()">S</button>
+            <button ng-class="{active: styleModel.bold}" ng-click="styleModel.bold = !styleModel.bold" class="btn style-btn" ng-model="styleModel.bold" btn-checkbox>
+                <strong>B</strong>
+            </button>
+            <button ng-class="{active: styleModel.underline}" ng-click="styleModel.underline = !styleModel.underline" class="btn style-btn" ng-model="styleModel.underline" btn-checkbox>
+                <u>U</u>
+            </button>
+            <button ng-class="{active: styleModel.italic}" class="btn style-btn" ng-click="styleModel.italic = !styleModel.italic"  ng-model="styleModel.italic" btn-checkbox >
+                <i>I</i>
+            </button>
+            <button ng-class="{active: styleModel.halo}" ng-click="styleModel.halo = !styleModel.halo" class="btn style-btn" ng-model="styleModel.halo" btn-checkbox>
+                H
+            </button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Fixed styling options for label outlines, had to remove `Shadow` option as SLD does not support it. `Cursive` as a font option had to be removed as an option because GeoServer does not have any cursive fonts available in the default installation.

https://github.com/MapStory/story-tools-composer/issues/103

![styles](https://user-images.githubusercontent.com/205525/43412954-b3125d62-93fc-11e8-9a21-9dee894e3dce.gif)
![color](https://user-images.githubusercontent.com/205525/43412961-b549eb40-93fc-11e8-814f-57b811b5a186.gif)
![font](https://user-images.githubusercontent.com/205525/43412964-b6eaa1b0-93fc-11e8-9206-1f0d5c73c26f.gif)
